### PR TITLE
Adds paths for .net 4.8, adds logging of tool lookup with diagnostic …

### DIFF
--- a/src/Cake.Mage/DotNetToolResolver.cs
+++ b/src/Cake.Mage/DotNetToolResolver.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Mage
@@ -14,9 +14,10 @@ namespace Cake.Mage
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;
         private readonly IRegistry _registry;
+        private readonly ICakeLog _log;
         private FilePath _toolPath;
 
-        public DotNetToolResolver(IFileSystem fileSystem, ICakeEnvironment environment, IRegistry registry)
+        public DotNetToolResolver(IFileSystem fileSystem, ICakeEnvironment environment, IRegistry registry, ICakeLog log)
         {
             if (fileSystem == null) throw new ArgumentNullException(nameof(fileSystem));
             if (registry == null) throw new ArgumentNullException(nameof(registry));
@@ -25,6 +26,7 @@ namespace Cake.Mage
             _fileSystem = fileSystem;
             _environment = environment;
             _registry = registry;
+            _log = log;
         }
 
         public FilePath GetPath(string toolExecutable)
@@ -54,31 +56,48 @@ namespace Cake.Mage
             var programFiles64Bit = _environment.GetSpecialPath(SpecialPath.ProgramFiles);
 
             // Gets a list of the files we should check.
-            var files = new List<FilePath>
+            var toolDirectories = new List<DirectoryPath>
             {
                 // 64-bit
-                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools").CombineWithFilePath(toolExecutable),
-                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools").CombineWithFilePath(toolExecutable),
-                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools").CombineWithFilePath(toolExecutable),
-                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools").CombineWithFilePath(toolExecutable),
-                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools").CombineWithFilePath(toolExecutable),
-                programFiles64Bit.Combine(@"Windows Kits\8.1\bin\x64").CombineWithFilePath(toolExecutable),
-                programFiles64Bit.Combine(@"Windows Kits\8.0\bin\x64").CombineWithFilePath(toolExecutable),
-                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v7.1A\Bin").CombineWithFilePath(toolExecutable),
+                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools"),
+                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools"),
+                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools"),
+                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools"),
+                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools"),
+                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools"),
+                programFiles64Bit.Combine(@"Windows Kits\8.1\bin\x64"),
+                programFiles64Bit.Combine(@"Windows Kits\8.0\bin\x64"),
+                programFiles64Bit.Combine(@"Microsoft SDKs\Windows\v7.1A\Bin"),
 
                 // x86
-                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools").CombineWithFilePath(toolExecutable),
-                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools").CombineWithFilePath(toolExecutable),
-                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools").CombineWithFilePath(toolExecutable),
-                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools").CombineWithFilePath(toolExecutable),
-                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools").CombineWithFilePath(toolExecutable),
-                programFilesX86.Combine(@"Windows Kits\8.1\bin\x86").CombineWithFilePath(toolExecutable),
-                programFilesX86.Combine(@"Windows Kits\8.0\bin\x86").CombineWithFilePath(toolExecutable),
-                programFilesX86.Combine(@"Microsoft SDKs\Windows\v7.1A\Bin").CombineWithFilePath(toolExecutable)
+                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools"),
+                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools"),
+                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools"),
+                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools"),
+                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools"),
+                programFilesX86.Combine(@"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools"),
+                programFilesX86.Combine(@"Windows Kits\8.1\bin\x86"),
+                programFilesX86.Combine(@"Windows Kits\8.0\bin\x86"),
+                programFilesX86.Combine(@"Microsoft SDKs\Windows\v7.1A\Bin")
             };
 
-            // Return the first path that exist.
-            return files.FirstOrDefault(file => _fileSystem.Exist(file));
+            foreach(var toolDirectory in toolDirectories)
+            {
+                var toolDirectoryExists = _fileSystem.Exist(toolDirectory);
+                _log.Debug($"{typeof(DotNetToolResolver)}: \"{toolDirectory}\" {(toolDirectoryExists ? "found" : "not found")}.");
+                
+                if (toolDirectoryExists)
+                {
+                    var toolFile = toolDirectory.CombineWithFilePath(toolExecutable);
+                    var toolFileExists = _fileSystem.Exist(toolFile);
+                    _log.Debug($"{typeof(DotNetToolResolver)}: \"{toolFile}\" {(toolFileExists ? "found" : "not found")}.");
+
+                    if (toolFileExists)
+                        return toolFile;
+                }
+            }
+
+            return null;
         }
 
         private FilePath GetFromRegistry(string toolExecutable)

--- a/src/Cake.Mage/MageAliases.cs
+++ b/src/Cake.Mage/MageAliases.cs
@@ -108,15 +108,15 @@ namespace Cake.Mage
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
 
-            var resolver = new DotNetToolResolver(context.FileSystem, context.Environment, context.Registry);
-            var runner = new SignMageTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Registry, resolver);
+            var resolver = new DotNetToolResolver(context.FileSystem, context.Environment, context.Registry, context.Log);
+            var runner = new SignMageTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Registry, context.Log, resolver);
             runner.Sign(settings);
         }
 
         private static void NewOrUpdate(ICakeContext context, BaseNewAndUpdateMageSettings settings)
         {
-            var resolver = new DotNetToolResolver(context.FileSystem, context.Environment, context.Registry);
-            var runner = new NewOrUpdateMageTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Registry, resolver);
+            var resolver = new DotNetToolResolver(context.FileSystem, context.Environment, context.Registry, context.Log);
+            var runner = new NewOrUpdateMageTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Registry, context.Log, resolver);
             runner.NewOrUpdate(settings);
         }
     }

--- a/src/Cake.Mage/MageRunner.cs
+++ b/src/Cake.Mage/MageRunner.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -19,10 +20,10 @@ namespace Cake.Mage
         private readonly DotNetToolResolver _resolver;
         protected readonly ICakeEnvironment Environment;
 
-        protected MageTool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools, IRegistry registry, DotNetToolResolver dotNetToolResolver) : base(fileSystem, environment, processRunner, tools)
+        protected MageTool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools, IRegistry registry, ICakeLog log, DotNetToolResolver dotNetToolResolver) : base(fileSystem, environment, processRunner, tools)
         {
             Environment = environment;
-            _resolver = dotNetToolResolver ?? new DotNetToolResolver(fileSystem, Environment, registry);
+            _resolver = dotNetToolResolver ?? new DotNetToolResolver(fileSystem, Environment, registry, log);
         }
 
         /// <summary>

--- a/src/Cake.Mage/NewOrUpdateMageTool.cs
+++ b/src/Cake.Mage/NewOrUpdateMageTool.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -81,7 +82,7 @@ namespace Cake.Mage
                 .AppendIfNotDefaultSwitch("-w", settings.WpfBrowserApp, false);            
         }
 
-        internal NewOrUpdateMageTool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools, IRegistry registry, DotNetToolResolver dotNetToolResolver) : base(fileSystem, environment, processRunner, tools, registry, dotNetToolResolver)
+        internal NewOrUpdateMageTool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools, IRegistry registry, ICakeLog log, DotNetToolResolver dotNetToolResolver) : base(fileSystem, environment, processRunner, tools, registry, log, dotNetToolResolver)
         {
         }
     }

--- a/src/Cake.Mage/SignMageTool.cs
+++ b/src/Cake.Mage/SignMageTool.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -33,8 +34,8 @@ namespace Cake.Mage
         }
 
         internal SignMageTool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner,
-            IToolLocator tools, IRegistry registry, DotNetToolResolver dotNetToolResolver)
-            : base(fileSystem, environment, processRunner, tools, registry, dotNetToolResolver)
+            IToolLocator tools, IRegistry registry, ICakeLog log, DotNetToolResolver dotNetToolResolver)
+            : base(fileSystem, environment, processRunner, tools, registry, log, dotNetToolResolver)
         {
         }
     }


### PR DESCRIPTION
With the recommended .net framework version 4.8 I have added its SDK tools path to the DotNetToolResolver. Also, I have added diagnostic logging of the tool lookup to diagnose problems I had with the DotNetToolResolver from nuget v6.0.1 being unable to locate the tool.